### PR TITLE
Adding device tree overlays for new linux kernels. 

### DIFF
--- a/linux/device-tree-overlays/BB-SPI0DEV-00A0.dts
+++ b/linux/device-tree-overlays/BB-SPI0DEV-00A0.dts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2013 CircuitCo
+ *
+ * Virtual cape for SPI0 on connector pins P9.22 P9.21 P9.18 P9.17
+ * Modified to enable /dev/spidev1.0 by Carl Johnson
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+/dts-v1/;
+/plugin/;
+
+/ {
+    compatible = "ti,beaglebone", "ti,beaglebone-black";
+
+    /* identification */
+    part-number = "BB-SPI0DEV";
+    version = "00A0";
+
+    /* state the resources this cape uses */
+    exclusive-use =
+        /* the pin header uses */
+        "P9.17",    /* spi0_cs0 */
+        "P9.18",    /* spi0_d1 */
+        "P9.21",    /* spi0_d0 */
+        "P9.22",    /* spi0_sclk */
+        /* the hardware ip uses */
+        "spi0";
+
+    fragment@0 {
+        target = <&am33xx_pinmux>;
+        __overlay__ {
+            bb_spi0_pins: pinmux_bb_spi0_pins {
+                pinctrl-single,pins = <
+                    0x150 0x30  /* spi0_sclk.spi0_sclk, INPUT_PULLUP | MODE0 */
+                    0x154 0x30  /* spi0_d0.spi0_d0, INPUT_PULLUP | MODE0 */
+                    0x158 0x10  /* spi0_d1.spi0_d1, OUTPUT_PULLUP | MODE0 */
+                    0x15c 0x10  /* spi0_cs0.spi0_cs0, OUTPUT_PULLUP | MODE0 */
+                >;
+            };
+        };
+    };
+
+    fragment@1 {
+        target = <&spi0>;   /* spi0 is numbered correctly */
+        __overlay__ {
+            status = "okay";
+            pinctrl-names = "default";
+            pinctrl-0 = <&bb_spi0_pins>;
+            #address-cells = <1>;
+            #size-cells = <0>;
+            spidev@0 {
+                #address-cells = <1>;
+                #size-cells = <0>;
+                spi-max-frequency = <24000000>;
+                reg = <0>;
+                compatible = "linux,spidev";
+            };
+        };
+    };
+};

--- a/linux/device-tree-overlays/OPENROV-RESET-00A0.dts
+++ b/linux/device-tree-overlays/OPENROV-RESET-00A0.dts
@@ -1,0 +1,50 @@
+/* 
+
+#compile 
+dtc -O dtb -o OPENROV-RESET-00A0.dtbo -b 0 -@ OPENROV-RESET-00A0.dts  
+cp OPENROV-RESET-00A0.dtbo /lib/firmware
+
+echo OPENROV-RESET > /sys/devices/bone_capemgr.7/slots
+
+export SLOTS=/sys/devices/bone_capemgr.7/slots
+export PINS=/sys/kernel/debug/pinctrl/44e10800.pinmux/pins
+
+
+*/
+/dts-v1/;
+/plugin/;
+
+/{
+       compatible = "ti,beaglebone", "ti,beaglebone-black";
+       part-number = "OPENROV-RESET";
+       version = "00A0";
+
+       fragment@0 {
+             target = <&am33xx_pinmux>;
+            
+             __overlay__ {
+                  pinctrl_test: openrov_reset_pin {
+            pinctrl-single,pins = <
+
+                0x000 0x07  /* P8_25 is the first GPIO pin, therefore offset 0x000 */
+
+                   /* OUTPUT  GPIO(mode7) 0x07 pulldown, 0x17 pullup, 0x?f no pullup/down */
+                   /* INPUT   GPIO(mode7) 0x27 pulldown, 0x37 pullup, 0x?f no pullup/down */
+
+            >;
+          };
+             };
+       };
+
+       fragment@1 {
+        target = <&ocp>;
+        __overlay__ {
+            test_helper: helper {
+                compatible = "bone-pinmux-helper";
+                pinctrl-names = "default";
+                pinctrl-0 = <&pinctrl_test>;
+                status = "okay";
+            };
+        };
+    };
+};


### PR DESCRIPTION
This is related to OpenROV/openrov-image#21
