### PR TITLE
The removal of the openrov-emmc-copy package has to be done as chroot in...

### DIFF
--- a/linux/copy-to-emmc.sh
+++ b/linux/copy-to-emmc.sh
@@ -272,6 +272,10 @@ copy_rootfs () {
 	echo "${boot_uuid}  /boot/uboot  auto  defaults  0  0" >> /tmp/rootfs/etc/fstab
 	echo "debugfs         /sys/kernel/debug  debugfs  defaults          0  0" >> /tmp/rootfs/etc/fstab
 	flush_cache
+
+	#OPENROV
+	chroot /tmp/rootfs /usr/bin/dpkg -r openrov-emmc-copy
+
 	umount ${destination}p2 || true
 
 	if [ -e /sys/class/leds/beaglebone\:green\:usr0/trigger ] ; then


### PR DESCRIPTION
... the new root, so we move it here
