### PR TITLE
Set socket.io version to 0.9.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "express": "= 3.4.8",
     "serialport": ">= 1.0.8",
     "ejs": "~0.8.3",
-    "socket.io": "",
+    "socket.io": "~0.9.17",
     "nconf" : "",
     "request" : "",
     "moment" : "",


### PR DESCRIPTION
io.configure has been removed in socket.io 1.0. With master, the message `TypeError: Object #<Server> has no method 'configure'` is output.

Updating to 1.0.2 seems to fix the startup issue, but there may be bugs. To be safe I would recommend putting it at 0.9.17 for the time being.
