### PR TITLE
Fix bower script in package.config 

### DIFF
--- a/src/static/package.json
+++ b/src/static/package.json
@@ -1,6 +1,6 @@
 {
   "name": "static-openrov",
-  "dev-dependencies": {
+  "devDependencies": {
     "bower": "^1.3.3"
   },
   "scripts": {


### PR DESCRIPTION
The way the bower install was fixed for the build server is not the correct way.
We should use a locally installed bower and have the correct parameters to bower.

There will be an accompanying pull request for the image project. 
