### PR TITLE
InputController now handles re-registering other controllers after a deactivation of another control

### DIFF
--- a/src/system-plugins/input-controller/public/js/input-controller.js
+++ b/src/system-plugins/input-controller/public/js/input-controller.js
@@ -98,9 +98,7 @@
 
         command.active = true;
         registerControls(command);
-//        controllers.forEach(function (controller) {
-//          controller.register(command);
-//        });
+
 
         console.log("activated command " + command.name);
       });


### PR DESCRIPTION
The bug is fixed in testing. There is still some funny business around the system blindly re-registering all controls each time a control is reregistered that could be simplified.  The duplicate detection should probably be stripped out since we have a binding level associative array that can be used for duplicate detection now.
