### PR TITLE
Added LiFePO4 batteries & set to default

### DIFF
--- a/src/plugins/capestatus/index.js
+++ b/src/plugins/capestatus/index.js
@@ -88,8 +88,9 @@ function capestatus(name, deps) {
       preferences = {
         batteries: [
           new Battery('TrustFire', 8.0, 13.0)
+          new Battery('LiFePO4',6.6,10.9)
         ],
-        selectedBattery: 'TrustFire'
+        selectedBattery: 'LiFePO4'
       };
       config.preferences.set(PREFERENCES, preferences);
     }


### PR DESCRIPTION
Added LiFePO4 batteries to the list and set them as the default option. Upper voltage is set to 10.9 Volts (circa 3 \* 3.65V) and lower to 6.6V (3 \* 2.2V) (values according to http://www.powerstream.com/LLLF.htm, set the lower limit a bit higher than absolute minimum to have a healthy security gap).
