### PR TITLE
fixed #290; reworked timing

### DIFF
--- a/src/lib/Hardware.js
+++ b/src/lib/Hardware.js
@@ -33,12 +33,22 @@ function Hardware() {
         hardware.emit('serial-recieved', data + '\n');
     });
   };
+
+
+  // This code intentionally spaces out the serial commands so that the buffer does not overflow
+  var timesent = new Date();
   hardware.write = function (command) {
     logger.log(command);
     if (CONFIG.production && serialConnected) {
-      hardware.serial.write(command);
-      if (emitRawSerialData)
-        hardware.emit('serial-sent', command);
+      var currenttime = new Date();
+      var delay = 3-((currenttime.getTime() - timesent.getTime()));
+      if (delay < 0) delay == 0;
+      timesent = currenttime; 
+      timesent.setMilliseconds(timesent.getMilliseconds + delay);
+      setTimeout(function(){
+        hardware.serial.write(command);
+        if (emitRawSerialData)  hardware.emit('serial-sent', command);
+      }, delay);
     } else {
       logger.log('DID NOT SEND');
     }

--- a/src/plugins/ready/index.js
+++ b/src/plugins/ready/index.js
@@ -34,18 +34,6 @@ function readyAyeReady(name, deps) {
   }
 
 
-  // to get the Arduino ready, request the capabilities
-  var checkId = setInterval(
-     function() {
-      if (! deps.rov.notSafeToControl()) {
-        clearInterval(checkId);
-      }
-      else {
-        deps.rov.requestCapabilities();
-      }
-    },
-    200);
-
   deps.rov.on('command', function(command) {
    lastLightCmd = command;
   });


### PR DESCRIPTION
Because the potential to overflow the arduino buffer, I added a bit of timing code to ensure each command had at least 3 ms separating them.  More than enough time for the arduino to clear the buffer.
Broke down the motor config code to smaller messages (paired with the Arduino matching PR)
Reworked at least temporarily the initialization code so that all the config settings are sent when trying to figure out if it is safe to control the ROV.  Pulled the conflicting code from the ready plugin.
