### PR TITLE
Fix a typo and make delay non-negative in serial comms throttling code.

### DIFF
--- a/src/lib/Hardware.js
+++ b/src/lib/Hardware.js
@@ -42,7 +42,7 @@ function Hardware() {
     if (CONFIG.production && serialConnected) {
       var currenttime = new Date();
       var delay = 3-((currenttime.getTime() - timesent.getTime()));
-      if (delay < 0) delay == 0;
+      if (delay < 0) delay = 0;
       timesent = currenttime; 
       timesent.setMilliseconds(timesent.getMilliseconds + delay);
       setTimeout(function(){


### PR DESCRIPTION
I think it was the original intention here.
