### PR TITLE
fixed #392; fast IMU updates

### DIFF
--- a/src/lib/OpenROVController.js
+++ b/src/lib/OpenROVController.js
@@ -30,18 +30,17 @@ var OpenROVController = function (eventLoop, client) {
   this.hardware = new Hardware();
   this.cockpit = client;
 
-  setInterval(function () {
-    controller.emit('status', statusdata);
-  }, 1000);
-
   this.hardware.on('serial-recieved', function (data) {
     globalEventLoop.emit('serial-recieved', data);
   });
 
   this.hardware.on('status', function (status) {
+    statusdata = {};
+
     for (var i in status) {
       statusdata[i] = status[i];
     }
+    controller.emit('status', statusdata);
     if ('ver' in status) {
       controller.ArduinoFirmwareVersion = status.ver;
     }

--- a/src/plugins/telemetry/index.js
+++ b/src/plugins/telemetry/index.js
@@ -1,8 +1,20 @@
 function telemetry(name, deps) {
   console.log('This is where Telemetry code would execute in the node process.');
 
+  var statusdata = {};
+
   deps.rov.on('status', function(data){
-    deps.cockpit.emit('plugin.telemetry.logData', data);
+    for (var i in data) {
+      statusdata[i] = data[i];
+    }
   });
+
+
+  setInterval(function () {
+    deps.cockpit.emit('plugin.telemetry.logData', statusdata);
+  }, 1000);
+
+
+
 }
 module.exports = telemetry;


### PR DESCRIPTION
Speeds up the nav-data updates by allowing the status messages to flow in as fast as they can.  The telemetry does the caching of the results to send the 1HZ updates down to the telemetry windows.

Will hold open for comments until May 14th 2015 for comments before committing.